### PR TITLE
Warning users about non-staged test files, small typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ gem install test_launcher
 ```
 
 Under the hood, it uses git to determine your project root. If you're on an app that's not using git, let me know and I can remove that dependency.
+Also, make sure that the test file you want to run is either staged or committed, otherwise it won't be found.
 
 # Examples
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ It was built for Minitest, but it also has basic support for RSpec and ExUnit.
 1. [Installation](#installation)
 1. [Examples](#examples)
 1. [Usage and Options](#usage-and-options)
-1. [Search Prioty](#search-priority)
+1. [Search Priority](#search-priority)
 1. [Running all changed tests](#running-all-changed-tests)
 1. [Tweaking the Command](#tweaking-the-command)
 1. [Aliases](#quit-typing-so-much)


### PR DESCRIPTION
I couldn't understand why running `test_launcher absolute_path/test_file.rb` was working but `test_launcher absolute_path/test_file.rb:6` wasn't, and after a while I discovered that if the test file is not staged or committed, it won't work.
After reading the readme I couldn't find anything related to line numbers, and the only mention about Git is that is used for determining the root of the project, so I thought that I could spare some time to other people too!

Thank you so much for this nifty tool, Pete! It saves me lots of time during my work day - I'm always suggesting it to my coworkers! ❤️
